### PR TITLE
Allow using variables in defaults.yml

### DIFF
--- a/colcon_defaults/argument_parser/defaults.py
+++ b/colcon_defaults/argument_parser/defaults.py
@@ -72,6 +72,7 @@ class DefaultArgumentsDecorator(DestinationCollectorDecorator):
             return {}
 
         content = path.read_text()
+        content = self._replace_default_variables(content)
         data = yaml.safe_load(content)
         if data is None:
             logger.info(
@@ -86,6 +87,15 @@ class DefaultArgumentsDecorator(DestinationCollectorDecorator):
         logger.info(
             "Using configuration from '%s'" % path.absolute())
         return data
+
+    def _replace_default_variables(self, content):
+        # Supported variables: current work directory
+        default_variables = {
+            '$CWD': os.getenv('CWD', os.getcwd()),
+        }
+        for k, v in default_variables.items():
+            content = content.replace(k, v)
+        return content
 
     def _filter_valid_default_values(self, data, group=None):
         for k in sorted(data.keys()):


### PR DESCRIPTION
This PR would allow, for example, to configure the path
to a toolchain file for workspaces with the same layout:

```
{
    "build": {
        "cmake-args": [
            '-DCMAKE_TOOLCHAIN_FILE="$CWD/path/to/toolchainfile.cmake"]
    },
}
```

- This PR stems from a conversation in https://github.com/ament/ament_cmake/issues/160#issuecomment-481004597
- I'm not sure this is the cleanest solution, but it was simpler than modifying all the different arguments parsers to find and replace instances of the supported variables, and I figured it would at least get the conversation started...
- A similar feature could be useful in `colcon-mixin` and/or `colcon-metadata`

