### PR TITLE
Allow embedded Python in defaults.yaml

### DIFF
--- a/colcon_defaults/argument_parser/defaults.py
+++ b/colcon_defaults/argument_parser/defaults.py
@@ -133,7 +133,7 @@ class DefaultArgumentsDecorator(DestinationCollectorDecorator):
             return {}
 
         content = path.read_text()
-        data = yaml.safe_load(content)
+        data = yaml.unsafe_load(content)
         if data is None:
             logger.info(
                 "Empty metadata file '%s'" % path.absolute())


### PR DESCRIPTION
safe_load prevents code injection in the yaml file, but this can be very useful, e.g.:

```
build:
  build_base: !!python/object/apply:os.getenv [MY_ENV_VAR]
```

The risk seems low since colcon.yaml is generally a local resource under user control and colcon doesn't sandbox other code execution.
