### PR TITLE
check type of default values if argument type is known

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,6 +1,8 @@
 apache
 colcon
 iterdir
+lstrip
+nargs
 noqa
 pathlib
 plugin


### PR DESCRIPTION
Replaces colcon/colcon-recursive-crawl#19.

While the type of an `argparse` argument can't be introspected in all cases it can be determined in several common cases. This patch ensures that the default values adhere to the type of the argument when it is known.