### PR TITLE
Switch to ActionCollectorDecorator, add SuppressRequiredActions

### DIFF
--- a/colcon_defaults/argument_parser/defaults.py
+++ b/colcon_defaults/argument_parser/defaults.py
@@ -7,10 +7,14 @@ from pathlib import Path
 from colcon_core.argument_default import wrap_default_value
 from colcon_core.argument_parser import ArgumentParserDecoratorExtensionPoint
 from colcon_core.argument_parser import SuppressUsageOutput
+from colcon_core.argument_parser.action_collector \
+    import ActionCollectorDecorator
+from colcon_core.argument_parser.action_collector \
+    import SuppressRequiredActions
+from colcon_core.argument_parser.action_collector \
+    import SuppressTypeConversions
 from colcon_core.argument_parser.destination_collector \
     import DestinationCollectorDecorator
-from colcon_core.argument_parser.type_collector import SuppressTypeConversions
-from colcon_core.argument_parser.type_collector import TypeCollectorDecorator
 from colcon_core.environment_variable import EnvironmentVariable
 from colcon_core.location import get_config_path
 from colcon_core.logging import colcon_logger
@@ -42,7 +46,7 @@ class DefaultArgumentsArgumentParserDecorator(
 
 
 class DefaultArgumentsDecorator(
-    DestinationCollectorDecorator, TypeCollectorDecorator
+    DestinationCollectorDecorator, ActionCollectorDecorator
 ):
     """Provide custom default values for command line arguments."""
 
@@ -108,7 +112,9 @@ class DefaultArgumentsDecorator(
         parsers_to_suppress = [self._parser] + list(all_parsers.values())
         with SuppressUsageOutput(parsers_to_suppress):
             with SuppressTypeConversions(parsers_to_suppress):
-                known_args, _ = self._parser.parse_known_args(*args, **kwargs)
+                with SuppressRequiredActions(parsers_to_suppress):
+                    known_args, _ = self._parser.parse_known_args(
+                        *args, **kwargs)
 
         data = self._get_defaults_values(self._config_path)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core>=0.7.0
+  colcon-core>=0.12.0
   PyYAML
 packages = find:
 zip_safe = true

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-defaults]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.7.0), python3-yaml
+Depends3: python3-colcon-core (>= 0.12.0), python3-yaml
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
It is necessary to suppress argument requirements during pre-parsing to ensure that missing positional arguments don't take precedence over the full --help text, which is already suppressed during pre-parsing.

Should be merged shortly after colcon/colcon-core#477 has been released, which is required for this change.