### PR TITLE
Expand environment variable defined in defaults.json

### DIFF
--- a/colcon_defaults/argument_parser/defaults.py
+++ b/colcon_defaults/argument_parser/defaults.py
@@ -170,7 +170,7 @@ class DefaultArgumentsDecorator(
             return {}
 
         content = path.read_text()
-        data = yaml.safe_load(content)
+        data = yaml.safe_load(os.path.expandvars(content))
         if data is None:
             logger.info(
                 "Empty metadata file '%s'" % path.absolute())


### PR DESCRIPTION
This is to allow defaults.json to reference an environment variable.