### PR TITLE
Fix behaviour with `packages-above-depth`

### DIFF
--- a/colcon_defaults/argument_parser/defaults.py
+++ b/colcon_defaults/argument_parser/defaults.py
@@ -207,6 +207,8 @@ class DefaultArgumentsDecorator(
                     except TypeError:
                         continue
                 defaults[dest] = wrap_default_value(value)
+            if key == "packages-above-depth":
+                defaults[dest][0] = int(defaults[dest][0])
         unknown_keys = data.keys() - destinations.keys()
         if unknown_keys:
             unknown_keys_str = ', '.join(sorted(unknown_keys))


### PR DESCRIPTION
Per #39, I think the overall experience gets broken when dealing with option "packages-above-depth".

This is most probably a BAD way to fix it (i.e. accepting a list of strings, where the first item gets forcible parsed into an integer) but at least it works.