### PR TITLE
Relax type enforcement with custom argparse actions

### DIFF
--- a/colcon_defaults/argument_parser/defaults.py
+++ b/colcon_defaults/argument_parser/defaults.py
@@ -108,6 +108,8 @@ class DefaultArgumentsDecorator(
             type_ = int
         elif kwargs.get('action') in ('store_false', 'store_true'):
             type_ = bool
+        elif callable(kwargs.get('action')):
+            type_ = None
         elif 'type' not in kwargs:
             type_ = str
         if kwargs.get('nargs') in ('*', '+'):


### PR DESCRIPTION
This code warns the user and ignores configuration defaults when the type isn't in the expected format. For custom types using a callable 'type' parameter, this code looks for a string input which is implicitly converted by argparse to the custom type by calling the given 'type' conversion function.

For custom actions, the parsed output cannot be known without invoking the action, which argparse does not do implicitly for given defaults. When the code specifies a custom action, we should relax the type enforcement.

This change doesn't bring support for all possible ways to trigger this issue. For example, a user may register a custom action behind a string identifier, or a custom action may result in a type which doesn't align with what 'nargs' says the argument should look like. I'm not aware of any use of either of those patterns in colcon today, so I think we should wait to decide how to handle them when we have a real use case to test against. For now, this change leaves that behavior as-is.

Closes #39
Closes #40